### PR TITLE
Fix collection dependency tests and re-enable Document Version rollback test

### DIFF
--- a/src/helpers/config/__tests__/collection-filtering.test.ts
+++ b/src/helpers/config/__tests__/collection-filtering.test.ts
@@ -534,7 +534,7 @@ describe('Collection Filtering', () => {
       expect(DocumentBlueprintCollection.metadata).toBeDefined();
       expect(DocumentBlueprintCollection.metadata.name).toBe('document-blueprint');
       expect(DocumentBlueprintCollection.metadata.displayName).toBe('Document Blueprints');
-      expect(DocumentBlueprintCollection.metadata.dependencies).toEqual([]);
+      expect(DocumentBlueprintCollection.metadata.dependencies).toEqual(['document-type', 'document']);
       expect(typeof DocumentBlueprintCollection.tools).toBe('function');
       
       const tools = DocumentBlueprintCollection.tools(mockUser);
@@ -556,7 +556,7 @@ describe('Collection Filtering', () => {
       expect(MediaCollection.metadata).toBeDefined();
       expect(MediaCollection.metadata.name).toBe('media');
       expect(MediaCollection.metadata.displayName).toBe('Media');
-      expect(MediaCollection.metadata.dependencies).toEqual([]);
+      expect(MediaCollection.metadata.dependencies).toEqual(['temporary-file']);
       expect(typeof MediaCollection.tools).toBe('function');
       
       const tools = MediaCollection.tools(mockUser);
@@ -589,7 +589,7 @@ describe('Collection Filtering', () => {
       expect(MemberGroupCollection.metadata).toBeDefined();
       expect(MemberGroupCollection.metadata.name).toBe('member-group');
       expect(MemberGroupCollection.metadata.displayName).toBe('Member Groups');
-      expect(MemberGroupCollection.metadata.dependencies).toEqual([]);
+      expect(MemberGroupCollection.metadata.dependencies).toEqual(['member', 'member-type']);
       expect(typeof MemberGroupCollection.tools).toBe('function');
       
       const tools = MemberGroupCollection.tools(mockUser);
@@ -600,7 +600,7 @@ describe('Collection Filtering', () => {
       expect(MemberTypeCollection.metadata).toBeDefined();
       expect(MemberTypeCollection.metadata.name).toBe('member-type');
       expect(MemberTypeCollection.metadata.displayName).toBe('Member Types');
-      expect(MemberTypeCollection.metadata.dependencies).toEqual([]);
+      expect(MemberTypeCollection.metadata.dependencies).toEqual(['member', 'member-group']);
       expect(typeof MemberTypeCollection.tools).toBe('function');
       
       const tools = MemberTypeCollection.tools(mockUser);
@@ -699,7 +699,7 @@ describe('Collection Filtering', () => {
       expect(TemporaryFileCollection.metadata).toBeDefined();
       expect(TemporaryFileCollection.metadata.name).toBe('temporary-file');
       expect(TemporaryFileCollection.metadata.displayName).toBe('Temporary Files');
-      expect(TemporaryFileCollection.metadata.dependencies).toEqual([]);
+      expect(TemporaryFileCollection.metadata.dependencies).toEqual(['media']);
       expect(typeof TemporaryFileCollection.tools).toBe('function');
       
       const tools = TemporaryFileCollection.tools(mockUser);

--- a/src/umb-management-api/tools/document-version/__tests__/create-document-version-rollback.test.ts
+++ b/src/umb-management-api/tools/document-version/__tests__/create-document-version-rollback.test.ts
@@ -21,7 +21,7 @@ describe("create-document-version-rollback", () => {
     console.error = originalConsoleError;
   });
 
-  it.skip("should rollback document to a specific version", async () => {
+  it("should rollback document to a specific version", async () => {
     // Arrange
     documentBuilder = new DocumentVersionBuilder()
       .withName(TEST_DOCUMENT_NAME)


### PR DESCRIPTION
## Summary

This is a small follow-up PR to fix test issues discovered after the merge of the main Document Version and Stylesheet implementation (#10).

### 🔧 Test Fixes

#### Collection Dependency Tests
Updates collection filtering tests to match the actual dependency declarations that were implemented:

- **DocumentBlueprintCollection**: `['document-type', 'document']`
- **MediaCollection**: `['temporary-file']` 
- **MemberGroupCollection**: `['member', 'member-type']`
- **MemberTypeCollection**: `['member', 'member-group']`
- **TemporaryFileCollection**: `['media']`

These tests were failing because the expected dependencies were still set to `[]` but the actual implementations now include proper dependency declarations.

#### Document Version Rollback Test  
Re-enables the Document Version rollback test by removing `.skip`:

- The test was working correctly and should be included in the CI pipeline
- All Document Version tests are now active and passing

### 🧪 Test Results

- ✅ All collection dependency tests now pass
- ✅ Document Version rollback test is now active and passing
- ✅ No breaking changes to existing functionality

### 📋 Files Changed

- `src/helpers/config/__tests__/collection-filtering.test.ts` - Updated dependency expectations
- `src/umb-management-api/tools/document-version/__tests__/create-document-version-rollback.test.ts` - Removed test skip

This PR ensures that all tests accurately reflect the current implementation and that the complete Document Version test suite is active.

🤖 Generated with [Claude Code](https://claude.ai/code)